### PR TITLE
Add idiomatic decode/1 and validate/1 functions

### DIFF
--- a/lib/token.ex
+++ b/lib/token.ex
@@ -75,6 +75,28 @@ defmodule Magic.Token do
   end
 
   @doc """
+    Decodes a DID Token from a Base64 string into a tuple of its individual
+    components: proof and claim. This method allows you decode the DID Token
+    and inspect the token
+    
+    Returns an :ok tuple with a map containing proof, claim and message or an error tuple
+  """
+  @spec decode(did_token) ::
+          {:ok, %{proof: String.t(), claim: claim, message: String.t()}}
+          | {:error, :malformed_did_token}
+  def decode(did_token) do
+    try do
+      [proof, message] = Base.decode64!(did_token) |> Jason.decode!()
+      claim = Jason.decode!(message)
+      validate_claim_fields!(claim)
+      {:ok, %{proof: proof, claim: claim, message: message}}
+    rescue
+      ArgumentError -> {:error, :malformed_did_token}
+      Jason.DecodeError -> {:error, :malformed_did_token}
+    end
+  end
+
+  @doc """
     Parses public_address and extracts issuer
     
     Returns issuer info

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -86,13 +86,10 @@ defmodule Magic.Token do
           | {:error, :malformed_did_token}
   def decode(did_token) do
     try do
-      [proof, message] = Base.decode64!(did_token) |> Jason.decode!()
-      claim = Jason.decode!(message)
-      validate_claim_fields!(claim)
-      {:ok, %{proof: proof, claim: claim, message: message}}
+      decoded = decode!(did_token)
+      {:ok, decoded}
     rescue
-      ArgumentError -> {:error, :malformed_did_token}
-      Jason.DecodeError -> {:error, :malformed_did_token}
+      DIDTokenError -> {:error, :malformed_did_token}
     end
   end
 

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -55,6 +55,22 @@ defmodule Magic.Token do
   end
 
   @doc """
+    Validates did_token
+    
+    Returns :ok or an error tuple
+  """
+  @spec validate(did_token) :: :ok | {:error, {:did_token_error, String.t()}}
+  def validate(did_token) do
+    try do
+      validate!(did_token)
+      :ok
+    rescue
+      e in DIDTokenError -> {:error, {:did_token_error, e.message}}
+
+    end
+  end
+
+  @doc """
     Decodes a DID Token from a Base64 string into a tuple of its individual
     components: proof and claim. This method allows you decode the DID Token
     and inspect the token
@@ -83,13 +99,13 @@ defmodule Magic.Token do
   """
   @spec decode(did_token) ::
           {:ok, %{proof: String.t(), claim: claim, message: String.t()}}
-          | {:error, :malformed_did_token}
+          | {:error, {:did_token_error, String.t()}}
   def decode(did_token) do
     try do
       decoded = decode!(did_token)
       {:ok, decoded}
     rescue
-      DIDTokenError -> {:error, :malformed_did_token}
+      e in DIDTokenError -> {:error, {:did_token_error, e.message}}
     end
   end
 

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -66,7 +66,6 @@ defmodule Magic.Token do
       :ok
     rescue
       e in DIDTokenError -> {:error, {:did_token_error, e.message}}
-
     end
   end
 

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -53,9 +53,23 @@ defmodule TokenTest do
     assert Token.validate!(did_token) == true
   end
 
-  test "decodes a DID token" do
+  test "decodes a DID token using decode!" do
     %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
     %{proof: proof, claim: claim} = Token.decode!(did_token)
+    assert proof == did_proof
+    assert claim["add"] == "fake_add"
+    assert claim["aud"] == "fake_aud"
+    assert claim["ext"] == did_claim["ext"]
+    assert claim["iat"] == did_claim["iat"]
+    assert claim["iss"] == did_claim["iss"]
+    assert claim["nbf"] == did_claim["nbf"]
+    assert claim["sub"] == "fake_sub"
+    assert claim["tid"] == "fake_tid"
+  end
+
+  test "decodes a DID token using decode" do
+    %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
+    {:ok, %{proof: proof, claim: claim}} = Token.decode(did_token)
     assert proof == did_proof
     assert claim["add"] == "fake_add"
     assert claim["aud"] == "fake_aud"
@@ -76,10 +90,14 @@ defmodule TokenTest do
     assert Token.get_issuer(did_token) == did_claim["iss"]
   end
 
-  test "raises an error if token is malformed" do
+  test "decode! raises an error if token is malformed" do
     assert_raise DIDTokenError, "DID Token is malformed", fn ->
       Token.decode!("malformed_token")
     end
+  end
+
+  test "decode returns an error tuple if token is malformed" do
+    assert Token.decode("malformed_token") == {:error, :malformed_did_token}
   end
 
   test "raises an error if token is missing fields" do

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -48,91 +48,142 @@ defmodule TokenTest do
     make_token(claim, private_key)
   end
 
-  test "validates a DID token" do
-    %{token: did_token} = token_fixture()
-    assert Token.validate!(did_token) == true
-  end
+  describe "validate!/1" do
+    test "validates a DID token" do
+      %{token: did_token} = token_fixture()
+      assert Token.validate!(did_token) == true
+    end
 
-  test "decodes a DID token using decode!" do
-    %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
-    %{proof: proof, claim: claim} = Token.decode!(did_token)
-    assert proof == did_proof
-    assert claim["add"] == "fake_add"
-    assert claim["aud"] == "fake_aud"
-    assert claim["ext"] == did_claim["ext"]
-    assert claim["iat"] == did_claim["iat"]
-    assert claim["iss"] == did_claim["iss"]
-    assert claim["nbf"] == did_claim["nbf"]
-    assert claim["sub"] == "fake_sub"
-    assert claim["tid"] == "fake_tid"
-  end
+    test "raises an error if token is missing fields" do
+      %{token: token} = token_fixture_missing_sub()
 
-  test "decodes a DID token using decode" do
-    %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
-    {:ok, %{proof: proof, claim: claim}} = Token.decode(did_token)
-    assert proof == did_proof
-    assert claim["add"] == "fake_add"
-    assert claim["aud"] == "fake_aud"
-    assert claim["ext"] == did_claim["ext"]
-    assert claim["iat"] == did_claim["iat"]
-    assert claim["iss"] == did_claim["iss"]
-    assert claim["nbf"] == did_claim["nbf"]
-    assert claim["sub"] == "fake_sub"
-    assert claim["tid"] == "fake_tid"
-  end
+      assert_raise DIDTokenError, "DID Token missing required fields: sub", fn ->
+        Token.validate!(token)
+      end
+    end
 
-  test "constructs issuer given public address" do
-    assert Token.construct_issuer_with_public_address("fake_addr") == "did:ethr:fake_addr"
-  end
+    test "raises an error if signature does not match claimed address" do
+      %{token: token} = token_fixture_bad_sig()
 
-  test "gets the issuer from an encoded token" do
-    %{token: did_token, claim: did_claim} = token_fixture()
-    assert Token.get_issuer(did_token) == did_claim["iss"]
-  end
+      assert_raise DIDTokenError, "Signature mismatch between 'proof' and 'claim'.", fn ->
+        Token.validate!(token)
+      end
+    end
 
-  test "decode! raises an error if token is malformed" do
-    assert_raise DIDTokenError, "DID Token is malformed", fn ->
-      Token.decode!("malformed_token")
+    test "raises an error if token is expired" do
+      %{token: token} = token_fixture_expired()
+
+      assert_raise DIDTokenError, "Given DID token has expired. Please generate a new one.", fn ->
+        Token.validate!(token)
+      end
+    end
+
+    test "raises an error if token is not yet in valid time usage window" do
+      %{token: token} = token_fixture_bad_nbf()
+
+      assert_raise DIDTokenError, "Given DID token cannot be used at this time.", fn ->
+        Token.validate!(token)
+      end
     end
   end
 
-  test "decode returns an error tuple if token is malformed" do
-    assert Token.decode("malformed_token") == {:error, :malformed_did_token}
-  end
-
-  test "raises an error if token is missing fields" do
-    %{token: token} = token_fixture_missing_sub()
-
-    assert_raise DIDTokenError, "DID Token missing required fields: sub", fn ->
-      Token.decode!(token)
+  describe "validate/1" do
+    test "validates a DID token" do
+      %{token: did_token} = token_fixture()
+      assert Token.validate(did_token) == :ok
     end
 
-    assert_raise DIDTokenError, "DID Token missing required fields: sub", fn ->
-      Token.validate!(token)
+    test "returns an error if token is missing fields" do
+      %{token: token} = token_fixture_missing_sub()
+
+      assert Token.validate(token) ==
+               {:error, {:did_token_error, "DID Token missing required fields: sub"}}
+    end
+
+    test "returns an error if signature does not match claimed address" do
+      %{token: token} = token_fixture_bad_sig()
+
+      assert Token.validate(token) ==
+               {:error, {:did_token_error, "Signature mismatch between 'proof' and 'claim'."}}
+    end
+
+    test "raises an error if token is expired" do
+      %{token: token} = token_fixture_expired()
+
+      assert Token.validate(token) ==
+               {:error,
+                {:did_token_error, "Given DID token has expired. Please generate a new one."}}
+    end
+
+    test "raises an error if token is not yet in valid time usage window" do
+      %{token: token} = token_fixture_bad_nbf()
+
+      assert Token.validate(token) ==
+               {:error, {:did_token_error, "Given DID token cannot be used at this time."}}
     end
   end
 
-  test "raises an error if signature does not match claimed address" do
-    %{token: token} = token_fixture_bad_sig()
+  describe "decode!/1" do
+    test "decodes a DID token" do
+      %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
+      %{proof: proof, claim: claim} = Token.decode!(did_token)
+      assert proof == did_proof
+      assert claim["add"] == "fake_add"
+      assert claim["aud"] == "fake_aud"
+      assert claim["ext"] == did_claim["ext"]
+      assert claim["iat"] == did_claim["iat"]
+      assert claim["iss"] == did_claim["iss"]
+      assert claim["nbf"] == did_claim["nbf"]
+      assert claim["sub"] == "fake_sub"
+      assert claim["tid"] == "fake_tid"
+    end
 
-    assert_raise DIDTokenError, "Signature mismatch between 'proof' and 'claim'.", fn ->
-      Token.validate!(token)
+    test "raises an error if token is malformed" do
+      assert_raise DIDTokenError, "DID Token is malformed", fn ->
+        Token.decode!("malformed_token")
+      end
+    end
+
+    test "raises an error if token is missing fields" do
+      %{token: token} = token_fixture_missing_sub()
+
+      assert_raise DIDTokenError, "DID Token missing required fields: sub", fn ->
+        Token.decode!(token)
+      end
     end
   end
 
-  test "raises an error if token is expired" do
-    %{token: token} = token_fixture_expired()
+  describe "decode/1" do
+    test "decodes a DID token" do
+      %{token: did_token, proof: did_proof, claim: did_claim} = token_fixture()
+      {:ok, %{proof: proof, claim: claim}} = Token.decode(did_token)
+      assert proof == did_proof
+      assert claim["add"] == "fake_add"
+      assert claim["aud"] == "fake_aud"
+      assert claim["ext"] == did_claim["ext"]
+      assert claim["iat"] == did_claim["iat"]
+      assert claim["iss"] == did_claim["iss"]
+      assert claim["nbf"] == did_claim["nbf"]
+      assert claim["sub"] == "fake_sub"
+      assert claim["tid"] == "fake_tid"
+    end
 
-    assert_raise DIDTokenError, "Given DID token has expired. Please generate a new one.", fn ->
-      Token.validate!(token)
+    test "returns an error tuple if token is malformed" do
+      assert Token.decode("malformed_token") ==
+               {:error, {:did_token_error, "DID Token is malformed"}}
     end
   end
 
-  test "raises an error if token is not yet in valid time usage window" do
-    %{token: token} = token_fixture_bad_nbf()
+  describe "construct_issuer_with_public_address/1" do
+    test "constructs issuer given public address" do
+      assert Token.construct_issuer_with_public_address("fake_addr") == "did:ethr:fake_addr"
+    end
+  end
 
-    assert_raise DIDTokenError, "Given DID token cannot be used at this time.", fn ->
-      Token.validate!(token)
+  describe "get_issuer/1" do
+    test "gets the issuer from an encoded token" do
+      %{token: did_token, claim: did_claim} = token_fixture()
+      assert Token.get_issuer(did_token) == did_claim["iss"]
     end
   end
 


### PR DESCRIPTION
addresses #1 

- adds `Token.decode/1` and `Token.validate/1`
- keeps the less-idiomatic `Token.decode!/1` and `Token.validate!/1` functions for backwards compatibility