### PR TITLE
Allow API secret key to be overridden at runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,12 @@
 use Mix.Config
 
-config :tesla, adapter: Tesla.Adapter.Hackney
+case Mix.env() do
+  :test ->
+    config :tesla, adapter: Tesla.MockAdapter
+
+  _ ->
+    config :tesla, adapter: Tesla.Adapter.Hackney
+end
 
 if File.exists?("config/config.secret.exs") do
   import_config "config.secret.exs"

--- a/lib/api.ex
+++ b/lib/api.ex
@@ -4,22 +4,20 @@ defmodule Magic.API do
   use Tesla
 
   def get_user(issuer, opts \\ []) do
-    secret_key = Keyword.get(opts, :secret_key, Application.get_env(:magic_admin, :secret_key))
-
-    client(secret_key)
+    client(opts)
     |> get("/v1/admin/auth/user/get", query: [issuer: issuer])
     |> process_response()
   end
 
   def logout_user(issuer, opts \\ []) do
-    secret_key = Keyword.get(opts, :secret_key, Application.get_env(:magic_admin, :secret_key))
-
-    client(secret_key)
+    client(opts)
     |> post("/v2/admin/auth/user/logout", %{issuer: issuer})
     |> process_response()
   end
 
-  defp client(secret_key) do
+  defp client(opts \\ []) do
+    secret_key = Keyword.get(opts, :secret_key, Application.get_env(:magic_admin, :secret_key))
+
     middleware = [
       {Tesla.Middleware.BaseUrl, "https://api.magic.link"},
       Tesla.Middleware.JSON,

--- a/lib/api.ex
+++ b/lib/api.ex
@@ -3,20 +3,33 @@ defmodule Magic.API do
 
   use Tesla
 
-  plug(Tesla.Middleware.BaseUrl, "https://api.magic.link")
+  def get_user(issuer, opts \\ []) do
+    secret_key = Keyword.get(opts, :secret_key, Application.get_env(:magic_admin, :secret_key))
 
-  plug(Tesla.Middleware.Headers, [
-    {"X-Magic-Secret-Key", Application.get_env(:magic_admin, :secret_key)}
-  ])
-
-  plug(Tesla.Middleware.JSON)
-
-  def get_user(issuer) do
-    get("/v1/admin/auth/user/get", query: [issuer: issuer]) |> process_response()
+    client(secret_key)
+    |> get("/v1/admin/auth/user/get", query: [issuer: issuer])
+    |> process_response()
   end
 
-  def logout_user(issuer) do
-    post("/v2/admin/auth/user/logout", %{issuer: issuer}) |> process_response()
+  def logout_user(issuer, opts \\ []) do
+    secret_key = Keyword.get(opts, :secret_key, Application.get_env(:magic_admin, :secret_key))
+
+    client(secret_key)
+    |> post("/v2/admin/auth/user/logout", %{issuer: issuer})
+    |> process_response()
+  end
+
+  defp client(secret_key) do
+    middleware = [
+      {Tesla.Middleware.BaseUrl, "https://api.magic.link"},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers,
+       [
+         {"X-Magic-Secret-Key", secret_key}
+       ]}
+    ]
+
+    Tesla.client(middleware)
   end
 
   defp process_response({:ok, %Tesla.Env{body: %{"status" => "ok", "data" => data}}}) do

--- a/lib/user.ex
+++ b/lib/user.ex
@@ -13,51 +13,51 @@ defmodule Magic.User do
   Retrieves information about the user by the supplied issuer
   """
   @spec get_metadata_by_issuer(issuer) :: {:ok, user} | {:error, String.t()}
-  def get_metadata_by_issuer(issuer) do
-    Magic.API.get_user(issuer)
+  def get_metadata_by_issuer(issuer, opts \\ []) do
+    Magic.API.get_user(issuer, opts)
   end
 
   @doc """
   Retrieves information about the user by the supplied public address
   """
   @spec get_metadata_by_public_address(public_address) :: {:ok, user} | {:error, String.t()}
-  def get_metadata_by_public_address(public_address) do
+  def get_metadata_by_public_address(public_address, opts \\ []) do
     issuer = Token.construct_issuer_with_public_address(public_address)
-    get_metadata_by_issuer(issuer)
+    get_metadata_by_issuer(issuer, opts)
   end
 
   @doc """
   Retrieves information about the user by the supplied DID Token
   """
   @spec get_metadata_by_token(did_token) :: {:ok, user} | {:error, String.t()}
-  def get_metadata_by_token(did_token) do
+  def get_metadata_by_token(did_token, opts \\ []) do
     issuer = Token.get_issuer(did_token)
-    get_metadata_by_issuer(issuer)
+    get_metadata_by_issuer(issuer, opts)
   end
 
   @doc """
   Logs a user out of all Magic SDK sessions by the supplied issuer
   """
   @spec logout_by_issuer(issuer) :: {:ok, %{}} | {:error, String.t()}
-  def logout_by_issuer(issuer) do
-    Magic.API.logout_user(issuer)
+  def logout_by_issuer(issuer, opts \\ []) do
+    Magic.API.logout_user(issuer, opts)
   end
 
   @doc """
   Logs a user out of all Magic SDK sessions by the supplied public address
   """
   @spec logout_by_public_address(public_address) :: {:ok, %{}} | {:error, String.t()}
-  def logout_by_public_address(public_address) do
+  def logout_by_public_address(public_address, opts \\ []) do
     issuer = Token.construct_issuer_with_public_address(public_address)
-    logout_by_issuer(issuer)
+    logout_by_issuer(issuer, opts)
   end
 
   @doc """
   Logs a user out of all Magic SDK sessions by the supplied DID Token
   """
   @spec logout_by_token(did_token) :: {:ok, %{}} | {:error, String.t()}
-  def logout_by_token(did_token) do
+  def logout_by_token(did_token, opts \\ []) do
     issuer = Token.get_issuer(did_token)
-    logout_by_issuer(issuer)
+    logout_by_issuer(issuer, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Magic.MixProject do
       {:ex_sha3, "~> 0.1.1"},
       {:ex_secp256k1, "~> 0.5"},
       {:tesla, "~> 1.4"},
-      {:hackney, "~> 1.17"}
+      {:hackney, "~> 1.17"},
+      {:mox, "~> 1.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,6 +13,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mox": {:hex, :mox, "1.0.2", "dc2057289ac478b35760ba74165b4b3f402f68803dd5aecd3bfd19c183815d64", [:mix], [], "hexpm", "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "rustler": {:hex, :rustler, "0.25.0", "32526b51af7e58a740f61941bf923486ce6415a91c3934cc16c281aa201a2240", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "6b43a11a37fe79c6234d88c4102ab5dfede7a6a764dc5c7b539956cfa02f3cf4"},

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -1,0 +1,72 @@
+defmodule ApiTest do
+  use ExUnit.Case
+  alias Magic.API
+
+  setup do
+    Application.put_env(:magic_admin, :secret_key, "some_api_key")
+  end
+
+  def user_fixture do
+    %{
+      "issuer" => "some_issuer",
+      "email" => "some@email.com",
+      "phoneNumber" => "some_phone_number",
+      "publicAddress" => "some_public_address"
+    }
+  end
+
+  describe "get_user/2" do
+    test "gets user by issuer" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.url == "https://api.magic.link/v1/admin/auth/user/get"
+        assert env.headers == [{"X-Magic-Secret-Key", "some_api_key"}]
+        assert env.query == [issuer: "some_issuer"]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} = API.get_user("some_issuer")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+
+    test "gets user by issuer with a different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.url == "https://api.magic.link/v1/admin/auth/user/get"
+        assert env.headers == [{"X-Magic-Secret-Key", "different_api_key"}]
+        assert env.query == [issuer: "some_issuer"]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} = API.get_user("some_issuer", secret_key: "different_api_key")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+  end
+
+  describe "logout_user/2" do
+    test "logs user out by issuer" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.url == "https://api.magic.link/v2/admin/auth/user/logout"
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "some_api_key"
+        assert env.body == Jason.encode!(%{issuer: "some_issuer"})
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+        # {:ok, env}
+      end)
+
+      assert API.logout_user("some_issuer") == {:ok, %{}}
+    end
+
+    test "gets user by issuer with a different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.url == "https://api.magic.link/v2/admin/auth/user/logout"
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "different_api_key"
+        assert env.body == Jason.encode!(%{issuer: "some_issuer"})
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      assert API.logout_user("some_issuer", secret_key: "different_api_key") == {:ok, %{}}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,73 @@
 ExUnit.start()
+Mox.defmock(Tesla.MockAdapter, for: Tesla.Adapter)
+
+defmodule TestHelper do
+  def token_fixture() do
+    private_key = ETH.Utils.get_private_key()
+    address = ETH.Utils.get_address(private_key)
+
+    make_token(default_claim(address), private_key)
+  end
+
+  def token_fixture_missing_sub() do
+    private_key = ETH.Utils.get_private_key()
+    address = ETH.Utils.get_address(private_key)
+
+    claim = default_claim(address) |> Map.delete("sub")
+
+    make_token(claim, private_key)
+  end
+
+  def token_fixture_bad_sig() do
+    private_key = ETH.Utils.get_private_key()
+    address = ETH.Utils.get_address(private_key)
+    bad_private_key = ETH.Utils.get_private_key()
+
+    make_token(default_claim(address), bad_private_key)
+  end
+
+  def token_fixture_expired() do
+    private_key = ETH.Utils.get_private_key()
+    address = ETH.Utils.get_address(private_key)
+
+    now = DateTime.utc_now() |> DateTime.to_unix()
+    claim = default_claim(address) |> Map.put("ext", now - 15 * 60)
+
+    make_token(claim, private_key)
+  end
+
+  def token_fixture_bad_nbf() do
+    private_key = ETH.Utils.get_private_key()
+    address = ETH.Utils.get_address(private_key)
+
+    now = DateTime.utc_now() |> DateTime.to_unix()
+    claim = default_claim(address) |> Map.put("nbf", now + 15 * 60)
+
+    make_token(claim, private_key)
+  end
+
+  defp default_claim(address) do
+    now = DateTime.utc_now() |> DateTime.to_unix()
+
+    %{
+      "add" => "fake_add",
+      "aud" => "fake_aud",
+      "ext" => now + 15 * 60,
+      "iat" => now,
+      "iss" => "did:ethr:#{address}",
+      "nbf" => now,
+      "sub" => "fake_sub",
+      "tid" => "fake_tid"
+    }
+  end
+
+  defp make_token(claim, private_key) do
+    message = Jason.encode!(claim)
+    hash = message |> Magic.Utils.prefix_message() |> ETH.Utils.keccak256()
+    [signature: signature, recovery: recovery] = ETH.Utils.secp256k1_signature(hash, private_key)
+    proof = <<signature::binary, recovery + 27::size(8)>> |> Magic.Utils.bin_to_hex()
+    token = [proof, message] |> Jason.encode!() |> Base.encode64()
+
+    %{token: token, proof: proof, claim: claim}
+  end
+end

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -3,50 +3,7 @@ defmodule TokenTest do
   doctest Magic.Token
   alias Magic.Token
   alias Magic.DIDTokenError
-
-  def token_fixture() do
-    private_key = ETH.Utils.get_private_key()
-    address = ETH.Utils.get_address(private_key)
-
-    make_token(default_claim(address), private_key)
-  end
-
-  def token_fixture_missing_sub() do
-    private_key = ETH.Utils.get_private_key()
-    address = ETH.Utils.get_address(private_key)
-
-    claim = default_claim(address) |> Map.delete("sub")
-
-    make_token(claim, private_key)
-  end
-
-  def token_fixture_bad_sig() do
-    private_key = ETH.Utils.get_private_key()
-    address = ETH.Utils.get_address(private_key)
-    bad_private_key = ETH.Utils.get_private_key()
-
-    make_token(default_claim(address), bad_private_key)
-  end
-
-  def token_fixture_expired() do
-    private_key = ETH.Utils.get_private_key()
-    address = ETH.Utils.get_address(private_key)
-
-    now = DateTime.utc_now() |> DateTime.to_unix()
-    claim = default_claim(address) |> Map.put("ext", now - 15 * 60)
-
-    make_token(claim, private_key)
-  end
-
-  def token_fixture_bad_nbf() do
-    private_key = ETH.Utils.get_private_key()
-    address = ETH.Utils.get_address(private_key)
-
-    now = DateTime.utc_now() |> DateTime.to_unix()
-    claim = default_claim(address) |> Map.put("nbf", now + 15 * 60)
-
-    make_token(claim, private_key)
-  end
+  import TestHelper
 
   describe "validate!/1" do
     test "validates a DID token" do
@@ -185,30 +142,5 @@ defmodule TokenTest do
       %{token: did_token, claim: did_claim} = token_fixture()
       assert Token.get_issuer(did_token) == did_claim["iss"]
     end
-  end
-
-  defp default_claim(address) do
-    now = DateTime.utc_now() |> DateTime.to_unix()
-
-    %{
-      "add" => "fake_add",
-      "aud" => "fake_aud",
-      "ext" => now + 15 * 60,
-      "iat" => now,
-      "iss" => "did:ethr:#{address}",
-      "nbf" => now,
-      "sub" => "fake_sub",
-      "tid" => "fake_tid"
-    }
-  end
-
-  defp make_token(claim, private_key) do
-    message = Jason.encode!(claim)
-    hash = message |> Magic.Utils.prefix_message() |> ETH.Utils.keccak256()
-    [signature: signature, recovery: recovery] = ETH.Utils.secp256k1_signature(hash, private_key)
-    proof = <<signature::binary, recovery + 27::size(8)>> |> Magic.Utils.bin_to_hex()
-    token = [proof, message] |> Jason.encode!() |> Base.encode64()
-
-    %{token: token, proof: proof, claim: claim}
   end
 end

--- a/test/user_test.exs
+++ b/test/user_test.exs
@@ -1,0 +1,164 @@
+defmodule UserTest do
+  use ExUnit.Case
+  alias Magic.User
+  import TestHelper
+
+  setup do
+    Application.put_env(:magic_admin, :secret_key, "some_api_key")
+  end
+
+  def user_fixture do
+    %{
+      "issuer" => "some_issuer",
+      "email" => "some@email.com",
+      "phoneNumber" => "some_phone_number",
+      "publicAddress" => "some_public_address"
+    }
+  end
+
+  describe "get_metadata_by_issuer/2" do
+    test "gets user given issuer" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "some_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} = User.get_metadata_by_issuer("some_issuer")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+
+    test "gets user given issuer with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "different_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} = User.get_metadata_by_issuer("some_issuer", secret_key: "different_api_key")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+  end
+
+  describe "get_metadata_by_public_address/2" do
+    test "gets user given public address" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "some_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} = User.get_metadata_by_public_address("some_public_address")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+
+    test "gets user given public address with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "different_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      {status, user} =
+        User.get_metadata_by_public_address("some_public_address", secret_key: "different_api_key")
+
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+  end
+
+  describe "get_metadata_by_token/2" do
+    test "gets user given token" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "some_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      %{token: did_token} = token_fixture()
+      {status, user} = User.get_metadata_by_token(did_token)
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+
+    test "gets user given token with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        assert env.headers == [{"X-Magic-Secret-Key", "different_api_key"}]
+        {:ok, %{env | body: %{"status" => "ok", "data" => user_fixture()}}}
+      end)
+
+      %{token: did_token} = token_fixture()
+      {status, user} = User.get_metadata_by_token(did_token, secret_key: "different_api_key")
+      assert status == :ok
+      assert user.email == "some@email.com"
+    end
+  end
+
+  describe "logout_by_issuer/2" do
+    test "logs out user given issuer" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "some_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      assert User.logout_by_issuer("some_issuer") == {:ok, %{}}
+    end
+
+    test "logs out user given issuer with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "different_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      assert User.logout_by_issuer("some_issuer", secret_key: "different_api_key") == {:ok, %{}}
+    end
+  end
+
+  describe "logout_by_public_address/2" do
+    test "logs out user given public address" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "some_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      assert User.logout_by_public_address("some_public_address") == {:ok, %{}}
+    end
+
+    test "logs out user given public address with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "different_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      assert User.logout_by_public_address("some_public_address", secret_key: "different_api_key") ==
+               {:ok, %{}}
+    end
+  end
+
+  describe "logout_by_token/2" do
+    test "logs out user given token" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "some_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      %{token: did_token} = token_fixture()
+      assert User.logout_by_token(did_token) == {:ok, %{}}
+    end
+
+    test "logs out user given public address with different secret key" do
+      Mox.expect(Tesla.MockAdapter, :call, fn env, _opts ->
+        {_, api_key} = List.keyfind(env.headers, "X-Magic-Secret-Key", 0)
+        assert api_key == "different_api_key"
+        {:ok, %{env | body: %{"status" => "ok", "data" => %{}}}}
+      end)
+
+      %{token: did_token} = token_fixture()
+      assert User.logout_by_token(did_token, secret_key: "different_api_key") ==
+               {:ok, %{}}
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability for the magic admin secret key to be overridden at runtime in addition to being set via `config`. This allows for multiple secret keys to be used within the same application